### PR TITLE
Add Hacker News service with caching and tests

### DIFF
--- a/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
+++ b/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using System.Threading;
 using System.Threading.Tasks;
 using HackerNewsAPI.Models;
+using System.Linq;
 
 public class HackerNewsServiceTests
 {
@@ -22,6 +23,21 @@ public class HackerNewsServiceTests
 
         Assert.Single(stories);
         Assert.Equal("Title", stories.First().Title);
+    }
+
+    [Fact]
+    public async Task FiltersBySearchTerm()
+    {
+        var handler = new FakeHttpHandler();
+        var client = new HttpClient(handler);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new HackerNewsService(client, cache);
+
+        var match = await service.GetNewStoriesAsync(1, 10, "Title");
+        Assert.Single(match);
+
+        var none = await service.GetNewStoriesAsync(1, 10, "Missing");
+        Assert.Empty(none);
     }
 }
 

--- a/HackerNewsAPI/Controllers/StoriesController.cs
+++ b/HackerNewsAPI/Controllers/StoriesController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace HackerNewsAPI.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("stories")]
 public class StoriesController : ControllerBase
 {
     private readonly IHackerNewsService _service;
@@ -15,8 +15,8 @@ public class StoriesController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IEnumerable<HackerNewsItem>> Get([FromQuery] int page = 1, [FromQuery] int pageSize = 10, [FromQuery] string? query = null)
+    public async Task<IEnumerable<HackerNewsItem>> Get([FromQuery] int page = 1, [FromQuery] int limit = 20, [FromQuery] string? search = null)
     {
-        return await _service.GetNewStoriesAsync(page, pageSize, query);
+        return await _service.GetNewStoriesAsync(page, limit, search);
     }
 }

--- a/HackerNewsAPI/Program.cs
+++ b/HackerNewsAPI/Program.cs
@@ -1,23 +1,12 @@
-using HackerNewsAPI.Services;
+using HackerNewsAPI;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-builder.Services.AddMemoryCache();
-builder.Services.AddHttpClient();
-builder.Services.AddScoped<IHackerNewsService, HackerNewsService>();
+var startup = new Startup(builder.Configuration);
+startup.ConfigureServices(builder.Services);
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
-
-app.UseHttpsRedirection();
-app.MapControllers();
+startup.Configure(app, app.Environment);
 
 app.Run();

--- a/HackerNewsAPI/Services/IHackerNewsService.cs
+++ b/HackerNewsAPI/Services/IHackerNewsService.cs
@@ -4,5 +4,5 @@ namespace HackerNewsAPI.Services;
 
 public interface IHackerNewsService
 {
-    Task<IEnumerable<HackerNewsItem>> GetNewStoriesAsync(int page, int pageSize, string? query);
+    Task<IEnumerable<HackerNewsItem>> GetNewStoriesAsync(int page, int limit, string? search);
 }

--- a/HackerNewsAPI/Startup.cs
+++ b/HackerNewsAPI/Startup.cs
@@ -1,0 +1,43 @@
+using HackerNewsAPI.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace HackerNewsAPI;
+
+public class Startup
+{
+    public IConfiguration Configuration { get; }
+
+    public Startup(IConfiguration configuration)
+    {
+        Configuration = configuration;
+    }
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen();
+        services.AddMemoryCache();
+        services.AddHttpClient();
+        services.AddScoped<IHackerNewsService, HackerNewsService>();
+    }
+
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI();
+        }
+
+        app.UseHttpsRedirection();
+        app.UseRouting();
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/stories` endpoint with pagination and search
- implement HackerNews service with in-memory caching
- register services via new Startup class
- add unit tests for story fetching and search filter

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_b_688f69506144832698a3c7b8705a7490