### PR TITLE
feat: add centered header and card layout with image previews

### DIFF
--- a/hn-viewer-app/src/app/app.css
+++ b/hn-viewer-app/src/app/app.css
@@ -6,3 +6,9 @@
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
+
+.app-title {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}

--- a/hn-viewer-app/src/app/app.html
+++ b/hn-viewer-app/src/app/app.html
@@ -1,4 +1,5 @@
 <div class="app-container">
+  <h1 class="app-title">hackerstream</h1>
   <app-search (search)="onSearch($event)"></app-search>
   <app-story-list [stories]="stories"></app-story-list>
   <app-pagination [page]="page" (pageChange)="onPageChange($event)"></app-pagination>

--- a/hn-viewer-app/src/app/components/story-list/story-list.css
+++ b/hn-viewer-app/src/app/components/story-list/story-list.css
@@ -2,9 +2,9 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
 }
 
 .story {
@@ -12,6 +12,18 @@
   padding: 0.75rem 1rem;
   border-radius: 6px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.story img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  object-fit: cover;
 }
 
 .story a {

--- a/hn-viewer-app/src/app/components/story-list/story-list.html
+++ b/hn-viewer-app/src/app/components/story-list/story-list.html
@@ -1,5 +1,6 @@
 <ul class="story-list">
   <li class="story" *ngFor="let story of validStories">
+    <img [src]="'https://picsum.photos/seed/' + story.id + '/200/150'" alt="{{story.title}}" />
     <a [href]="story.url" target="_blank" rel="noopener">{{story.title}}</a>
   </li>
 </ul>


### PR DESCRIPTION
## Summary
- add centered `hackerstream` header to main app layout
- show each story as a card with placeholder image preview
- arrange stories in a four-column grid for easier browsing

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_688f85a2604483269074431f70b6e243