### PR TITLE
Hide news without preview images

### DIFF
--- a/hn-viewer-app/src/app/components/story-list/story-list.html
+++ b/hn-viewer-app/src/app/components/story-list/story-list.html
@@ -1,6 +1,6 @@
 <ul class="story-list">
   <li class="story" *ngFor="let story of validStories">
-    <img [src]="'https://picsum.photos/seed/' + story.id + '/200/150'" alt="{{story.title}}" />
+    <img [src]="story.imageUrl" alt="{{story.title}}" />
     <a [href]="story.url" target="_blank" rel="noopener">{{story.title}}</a>
   </li>
 </ul>

--- a/hn-viewer-app/src/app/components/story-list/story-list.spec.ts
+++ b/hn-viewer-app/src/app/components/story-list/story-list.spec.ts
@@ -21,14 +21,15 @@ describe('StoryList', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display only stories with urls', () => {
+  it('should display only stories with urls and image previews', () => {
     component.stories = [
-      { id: 1, title: 'With URL', url: 'http://example.com' },
-      { id: 2, title: 'No URL', url: '' }
+      { id: 1, title: 'With URL and image', url: 'http://example.com', imageUrl: 'http://img.com/1.png' },
+      { id: 2, title: 'No URL', url: '', imageUrl: 'http://img.com/2.png' },
+      { id: 3, title: 'No image', url: 'http://example2.com', imageUrl: '' }
     ];
     fixture.detectChanges();
     const links = fixture.nativeElement.querySelectorAll('a');
     expect(links.length).toBe(1);
-    expect(links[0].textContent).toContain('With URL');
+    expect(links[0].textContent).toContain('With URL and image');
   });
 });

--- a/hn-viewer-app/src/app/components/story-list/story-list.ts
+++ b/hn-viewer-app/src/app/components/story-list/story-list.ts
@@ -11,6 +11,6 @@ export class StoryList {
   @Input() stories: Story[] = [];
 
   get validStories(): Story[] {
-    return this.stories.filter(s => !!s.url);
+    return this.stories.filter(s => !!s.url && !!s.imageUrl);
   }
 }

--- a/hn-viewer-app/src/app/services/hacker-news.spec.ts
+++ b/hn-viewer-app/src/app/services/hacker-news.spec.ts
@@ -19,7 +19,7 @@ describe('HackerNews', () => {
   });
 
   it('should fetch stories with query params', () => {
-    const dummy: Story[] = [{ id: 1, title: 'Test', url: 'http://example.com' }];
+    const dummy: Story[] = [{ id: 1, title: 'Test', url: 'http://example.com', imageUrl: 'http://img.com/1.png' }];
 
     service.getStories(1, 'test').subscribe(stories => {
       expect(stories.length).toBe(1);

--- a/hn-viewer-app/src/app/services/hacker-news.ts
+++ b/hn-viewer-app/src/app/services/hacker-news.ts
@@ -6,6 +6,7 @@ export interface Story {
   id: number;
   title: string;
   url: string;
+  imageUrl?: string;
 }
 
 @Injectable({


### PR DESCRIPTION
## Summary
- Exclude stories lacking URLs or image previews from the story list
- Update Story interface and unit tests to account for image preview data

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_688f889599308326867b4cc7a018e6a1