### PR TITLE
feat: add story sorting and loading feedback

### DIFF
--- a/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
+++ b/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
@@ -39,6 +39,20 @@ public class HackerNewsServiceTests
         var none = await service.GetNewStoriesAsync(1, 10, "Missing");
         Assert.Empty(none);
     }
+
+    [Fact]
+    public async Task IncludesScoreAndTime()
+    {
+        var handler = new FakeHttpHandler();
+        var client = new HttpClient(handler);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new HackerNewsService(client, cache);
+
+        var stories = await service.GetNewStoriesAsync(1, 10, null);
+        var story = stories.First();
+        Assert.Equal(10, story.Score);
+        Assert.Equal(1234, story.Time);
+    }
 }
 
 class FakeHttpHandler : HttpMessageHandler
@@ -49,7 +63,7 @@ class FakeHttpHandler : HttpMessageHandler
         string json = path switch
         {
             "/v0/newstories.json" => "[1]",
-            "/v0/item/1.json" => "{\"id\":1,\"title\":\"Title\",\"url\":\"http://example.com\"}",
+            "/v0/item/1.json" => "{\"id\":1,\"title\":\"Title\",\"url\":\"http://example.com\",\"score\":10,\"time\":1234}",
             _ => "{}"
         };
 

--- a/HackerNewsAPI/Models/HackerNewsItem.cs
+++ b/HackerNewsAPI/Models/HackerNewsItem.cs
@@ -5,4 +5,6 @@ public class HackerNewsItem
     public int Id { get; set; }
     public string? Title { get; set; }
     public string? Url { get; set; }
+    public int? Score { get; set; }
+    public long? Time { get; set; }
 }

--- a/hn-viewer-app/src/app/app.css
+++ b/hn-viewer-app/src/app/app.css
@@ -12,3 +12,49 @@
   margin-top: 0;
   margin-bottom: 1.5rem;
 }
+
+.sort-select {
+  margin-bottom: 1rem;
+}
+
+.skeleton-list {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.skeleton {
+  height: 150px;
+  background: #e0e0e0;
+  border-radius: 6px;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.5; }
+  100% { opacity: 1; }
+}
+
+.error {
+  color: #c00;
+  text-align: center;
+  margin: 1rem 0;
+}
+
+@media (max-width: 768px) {
+  .app-container {
+    margin: 0;
+    padding: 1rem;
+    box-shadow: none;
+  }
+  .skeleton-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .skeleton-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/hn-viewer-app/src/app/app.html
+++ b/hn-viewer-app/src/app/app.html
@@ -1,6 +1,15 @@
 <div class="app-container">
-  <h1 class="app-title">hackerstream</h1>
+  <h1 class="app-title">HackerStream</h1>
   <app-search (search)="onSearch($event)"></app-search>
-  <app-story-list [stories]="stories"></app-story-list>
+  <select class="sort-select" (change)="onSortChange($event.target.value)">
+    <option value="">Sort by</option>
+    <option value="score">Score</option>
+    <option value="time">Time</option>
+  </select>
+  <div *ngIf="loading" class="skeleton-list">
+    <div class="skeleton" *ngFor="let s of skeletons"></div>
+  </div>
+  <div *ngIf="error" class="error">{{ error }}</div>
+  <app-story-list *ngIf="!loading && !error" [stories]="stories" [sort]="sort"></app-story-list>
   <app-pagination [page]="page" (pageChange)="onPageChange($event)"></app-pagination>
 </div>

--- a/hn-viewer-app/src/app/app.ts
+++ b/hn-viewer-app/src/app/app.ts
@@ -11,6 +11,10 @@ export class App implements OnInit {
   stories: Story[] = [];
   page = 1;
   query = '';
+  sort: 'score' | 'time' | '' = '';
+  loading = false;
+  error = '';
+  skeletons = Array.from({ length: 8 });
 
   constructor(private hn: HackerNews) {}
 
@@ -19,7 +23,18 @@ export class App implements OnInit {
   }
 
   load() {
-    this.hn.getStories(this.page, this.query).subscribe(s => (this.stories = s));
+    this.loading = true;
+    this.error = '';
+    this.hn.getStories(this.page, this.query).subscribe({
+      next: s => {
+        this.stories = s;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load stories';
+        this.loading = false;
+      }
+    });
   }
 
   onSearch(q: string) {
@@ -31,5 +46,9 @@ export class App implements OnInit {
   onPageChange(p: number) {
     this.page = p;
     this.load();
+  }
+
+  onSortChange(sort: string) {
+    this.sort = sort as any;
   }
 }

--- a/hn-viewer-app/src/app/components/story-list/story-list.css
+++ b/hn-viewer-app/src/app/components/story-list/story-list.css
@@ -35,3 +35,21 @@
 .story a:hover {
   text-decoration: underline;
 }
+
+.meta {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .story-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .story-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/hn-viewer-app/src/app/components/story-list/story-list.html
+++ b/hn-viewer-app/src/app/components/story-list/story-list.html
@@ -2,5 +2,9 @@
   <li class="story" *ngFor="let story of validStories">
     <img [src]="'https://picsum.photos/seed/' + story.id + '/200/150'" alt="{{story.title}}" />
     <a [href]="story.url" target="_blank" rel="noopener">{{story.title}}</a>
+    <div class="meta">
+      <span *ngIf="story.score">Score: {{story.score}}</span>
+      <span *ngIf="story.time"> | {{ story.time * 1000 | date:'short' }}</span>
+    </div>
   </li>
 </ul>

--- a/hn-viewer-app/src/app/components/story-list/story-list.spec.ts
+++ b/hn-viewer-app/src/app/components/story-list/story-list.spec.ts
@@ -31,4 +31,13 @@ describe('StoryList', () => {
     expect(links.length).toBe(1);
     expect(links[0].textContent).toContain('With URL');
   });
+
+  it('should sort stories by score', () => {
+    component.stories = [
+      { id: 1, title: 'Low', url: 'http://a', score: 5 },
+      { id: 2, title: 'High', url: 'http://b', score: 10 }
+    ];
+    component.sort = 'score';
+    expect(component.validStories[0].id).toBe(2);
+  });
 });

--- a/hn-viewer-app/src/app/components/story-list/story-list.ts
+++ b/hn-viewer-app/src/app/components/story-list/story-list.ts
@@ -9,8 +9,16 @@ import { Story } from '../../services/hacker-news';
 })
 export class StoryList {
   @Input() stories: Story[] = [];
+  @Input() sort: 'score' | 'time' | '' = '';
 
   get validStories(): Story[] {
-    return this.stories.filter(s => !!s.url);
+    const filtered = this.stories.filter(s => !!s.url);
+    if (this.sort === 'score') {
+      return filtered.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    }
+    if (this.sort === 'time') {
+      return filtered.sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
+    }
+    return filtered;
   }
 }

--- a/hn-viewer-app/src/app/services/hacker-news.ts
+++ b/hn-viewer-app/src/app/services/hacker-news.ts
@@ -6,6 +6,8 @@ export interface Story {
   id: number;
   title: string;
   url: string;
+  score?: number;
+  time?: number;
 }
 
 @Injectable({


### PR DESCRIPTION
## Summary
- add score and time fields to stories and expose sorting UI
- show skeleton placeholders and error message during loading
- make layout responsive and cover new fields in backend tests

## Testing
- `CHROME_BIN=$(which chromium || which chromium-browser || true) npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_688fb9ae7b9c8326ad2ad38616133c69