### PR TITLE
Handle HTTP failures gracefully

### DIFF
--- a/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
+++ b/HackerNewsAPI.Tests/HackerNewsServiceTests.cs
@@ -53,6 +53,19 @@ public class HackerNewsServiceTests
         Assert.Equal(10, story.Score);
         Assert.Equal(1234, story.Time);
     }
+
+    [Fact]
+    public async Task ReturnsEmptyWhenRequestFails()
+    {
+        var handler = new ErrorHttpHandler();
+        var client = new HttpClient(handler);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new HackerNewsService(client, cache);
+
+        var stories = await service.GetNewStoriesAsync(1, 10, null);
+
+        Assert.Empty(stories);
+    }
 }
 
 class FakeHttpHandler : HttpMessageHandler
@@ -71,5 +84,13 @@ class FakeHttpHandler : HttpMessageHandler
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         });
+    }
+}
+
+class ErrorHttpHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
     }
 }


### PR DESCRIPTION
## Summary
- Handle HTTP request failures in `HackerNewsService` to avoid crashing when Hacker News API is unreachable
- Add unit test ensuring service returns empty results when HTTP calls fail

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden on repositories)*

------
https://chatgpt.com/codex/tasks/task_b_68923c714b5c8326b169353992c72619