### PR TITLE
Fix sort select event typing

### DIFF
--- a/hn-viewer-app/src/app/app.html
+++ b/hn-viewer-app/src/app/app.html
@@ -1,7 +1,7 @@
 <div class="app-container">
   <h1 class="app-title">HackerStream</h1>
   <app-search (search)="onSearch($event)"></app-search>
-  <select class="sort-select" (change)="onSortChange($event.target.value)">
+  <select class="sort-select" (change)="onSortChange($event)">
     <option value="">Sort by</option>
     <option value="score">Score</option>
     <option value="time">Time</option>

--- a/hn-viewer-app/src/app/app.ts
+++ b/hn-viewer-app/src/app/app.ts
@@ -48,7 +48,8 @@ export class App implements OnInit {
     this.load();
   }
 
-  onSortChange(sort: string) {
-    this.sort = sort as any;
+  onSortChange(event: Event) {
+    const value = (event.target as HTMLSelectElement | null)?.value ?? '';
+    this.sort = value as 'score' | 'time' | '';
   }
 }


### PR DESCRIPTION
## Summary
- avoid direct DOM value access in sort dropdown
- safely extract selected value from change event

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: Module './hacker-news' has no exported member 'HackerNewsService')*
- `dotnet test` *(fails: command not found; apt repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68923e8241788326ba24f7e8005816f4