### PR TITLE
Fix HackerNews service unit test

### DIFF
--- a/hn-viewer-app/src/app/services/hacker-news.spec.ts
+++ b/hn-viewer-app/src/app/services/hacker-news.spec.ts
@@ -1,16 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HackerNewsService, Story } from './hacker-news';
+import { HackerNews, Story } from './hacker-news';
 
-describe('HackerNewsService', () => {
-  let service: HackerNewsService;
+describe('HackerNews', () => {
+  let service: HackerNews;
   let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
-    service = TestBed.inject(HackerNewsService);
+    service = TestBed.inject(HackerNews);
     httpMock = TestBed.inject(HttpTestingController);
   });
 
@@ -20,16 +20,16 @@ describe('HackerNewsService', () => {
 
   it('should fetch stories', () => {
     const dummy: Story[] = [{ id: 1, title: 'Test', url: 'http://example.com' }];
-    const query = '';
     const page = 1;
+    const query = '';
 
-    service.getStories(query, page).subscribe((stories: Story[]) => {
+    service.getStories(page, query).subscribe((stories: Story[]) => {
       expect(stories.length).toBe(1);
       expect(stories[0].title).toBe('Test');
     });
 
-    const req = httpMock.expectOne(`/api/stories?search=&page=1&pageSize=20`);
+    const req = httpMock.expectOne('/api/stories?page=1&limit=20');
     expect(req.request.method).toBe('GET');
     req.flush(dummy);
   });
-}) ;
+});


### PR DESCRIPTION
## Summary
- align HackerNews service spec with HackerNews class
- check request uses `limit` query param

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68928c76945c8326aea260df008c067a